### PR TITLE
Use X_HTTP_REQUEST_ID header to bind request_id value in logger

### DIFF
--- a/gcpi/stackdriverlog/conf.py
+++ b/gcpi/stackdriverlog/conf.py
@@ -50,6 +50,8 @@ DEFAULTS = {
     'REQUEST_MIDDLEWARE_IGNORE_PATHS': [
         r'^/health/?$'
     ],
+    
+    'LOG_REQUEST_ID_HEADER': 'HTTP_X_REQUEST_ID',
 
     # If set True, force settings all log levels to DEBUG.
     'FORCE_DEBUG_LEVEL': False,

--- a/gcpi/stackdriverlog/contrib/django/middleware.py
+++ b/gcpi/stackdriverlog/contrib/django/middleware.py
@@ -31,8 +31,8 @@ class RequestLoggingMiddleware(object):
         request.logger = structlog.getLogger(__name__).bind(message=message,
             path=request.path, method=request.method, query_params=dict(request.GET))
 
-        if hasattr(request, 'tracking_id'):
-            request.logger = request.logger.bind(tracking_id=request.tracking_id)
+        if hasattr(request.META, settings.LOG_REQUEST_ID_HEADER):
+            request.logger = request.logger.bind(request_id=request.META[settings.LOG_REQUEST_ID_HEADER])
 
     def post_response(self, request, response):
         request.logger = request.logger.bind(status=response.status_code,


### PR DESCRIPTION
Fetch requests id from X_HTTP_REQUEST_ID header and rename logging field for requests id from tracking_id to request_id